### PR TITLE
Set defaults for token generation

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -160,7 +160,7 @@ class kai_bridge():
                 # By default, we don't want to be annoucing the prompt send from the Horde to the terminal
                 current_payload['quiet'] = True
                 requested_softprompt = pop['softprompt']
-            logger.info(f"Job received from {cluster} for {current_payload.get('max_length',80)} tokens and {current_payload.get('max_context_length',1024)} max context. Starting generation...")
+            logger.info(f"Job received from {cluster} for {current_payload.setdefault('max_length',80)} tokens and {current_payload.setdefault('max_context_length',1024)} max context. Starting generation...")
             if requested_softprompt != self.current_softprompt:
                 req = requests.put(kai_url + '/api/latest/config/soft_prompt/', json = {"value": requested_softprompt})
                 time.sleep(1) # Wait a second to unload the softprompt


### PR DESCRIPTION
Current behavior announces that a job for 80 tokens to generate and 1024 max tokens is received if either are not found. These values are not actually set and are never sent to the worker, causing them to use their own default token generation settings. This inadvertently makes a worker work harder if they're running at full context for what should have been a smaller job. This also causes worker speeds to become inaccurate.

Changing `current_payload.get` to `current_payload.setdefault` will return those values if found or set default values (80/1024) to the prompt before sending it to the worker.