### PR TITLE
fix that should prevent people from crashing horde workers

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -161,6 +161,11 @@ class kai_bridge():
                 current_payload['quiet'] = True
                 requested_softprompt = pop['softprompt']
             logger.info(f"Job received from {cluster} for {current_payload.setdefault('max_length',80)} tokens and {current_payload.setdefault('max_context_length',1024)} max context. Starting generation...")
+            
+            if "soft_prompt" in current_payload and current_payload["soft_prompt"] not in self.softprompts[self.model]:
+                #prevent unknown rogue softprompt from crashing horde worker
+                current_payload["soft_prompt"] = "" #this is a valid value that functions like no softprompt
+            
             if requested_softprompt != self.current_softprompt:
                 req = requests.put(kai_url + '/api/latest/config/soft_prompt/', json = {"value": requested_softprompt})
                 time.sleep(1) # Wait a second to unload the softprompt


### PR DESCRIPTION
fix that should prevent people from crashing horde workers either accidentally or maliciously on purpose. This happens when the "soft_prompt" field is (intentionally) populated with a non-empty string while also sending an empty string for the "softprompt" field which horde normally uses. The Horde assigns the job to the worker which cannot fulfill it, resulting in the worker dropping the job and eventually being sent into maintenance.

Please test/review, thanks!